### PR TITLE
FIX base_n_pay_card: initialise account_id in _cpt_bank_counterpart _…

### DIFF
--- a/base_newgen_payment_card/models/newgen_payment_card_transaction.py
+++ b/base_newgen_payment_card/models/newgen_payment_card_transaction.py
@@ -226,6 +226,7 @@ class NewgenPaymentCardTransaction(models.Model):
     @api.depends('partner_id', 'transaction_type', 'company_id')
     def _compute_bank_counterpart_account_id(self):
         for trans in self:
+            account_id = False
             if trans.transaction_type == 'load':
                 account_id = trans.company_id.transfer_account_id.id or False
             elif trans.transaction_type == 'expense':


### PR DESCRIPTION
…account_id

In some case account_id have no value, needs to be initialised

![payment_card](https://github.com/akretion/odoo-mooncard-connector/assets/1853434/ed52010a-d40c-449c-8534-6184f57f0aa7)

cc @florian-dacosta 