### PR TITLE
[FIX][16.0][base_newgen_payment_card] Align with recent updates merged in OCA/edi/account_invoice_import

### DIFF
--- a/base_newgen_payment_card/models/newgen_payment_card_transaction.py
+++ b/base_newgen_payment_card/models/newgen_payment_card_transaction.py
@@ -533,7 +533,8 @@ class NewgenPaymentCardTransaction(models.Model):
             'invoice_line_method': 'nline_no_product',
             'account': self.expense_account_id,
             'analytic_distribution': self.analytic_distribution or False,
-            }
+            'company': self.company_id,
+        }
         return import_config
 
     def generate_invoice(self):
@@ -542,7 +543,7 @@ class NewgenPaymentCardTransaction(models.Model):
         aiio = self.env['account.invoice.import']
         parsed_inv = self._prepare_invoice_import()
         logger.debug('Payment card invoice import parsed_inv=%s', parsed_inv)
-        parsed_inv = aiio.pre_process_parsed_inv(parsed_inv)
+        parsed_inv = aiio._pre_process_parsed_inv(parsed_inv, self.company_id)
         import_config = self._prepare_invoice_import_config()
         invoice = aiio.create_invoice(
             parsed_inv, import_config=import_config, origin='Mooncard connector')


### PR DESCRIPTION
Since recent merge of `account_invoice_import` in OCA/edi, the **"Validate"** button throw a Python error.
This simple aligns the methods of `account_invoice_import` used in `base_newgen_payment_card`

Note: also see [PR OCA/EDI1276](https://github.com/OCA/edi/pull/1273)
In OCA's `edi/account_invoice_import`, this write of `analytic_distribution` field was also removed from the method `account_invoice_import._prepare_create_invoice_vals()`. It should be restored just before `return` like below.

```python
        # Write analytic distribution
        analytic_distribution = import_config.get("analytic_distribution", False)
        if analytic_distribution:
            for line in vals["invoice_line_ids"]:
                line[2]["analytic_distribution"] = analytic_distribution

```

@alexis-via 